### PR TITLE
little capistrano cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ config/secrets.yml
 public/files
 public/assets
 .byebug_history
+.DS_Store
+/.idea/

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,11 +1,8 @@
-# Change these
-server '104.236.114.57', port: 2424, roles: [:web, :app, :db], primary: true
-
 set :repo_url,        'git@github.com:liveanimations/Norma4D.git'
 set :application,     'Norma4D'
 set :user,            'deployer'
-set :puma_threads,    [4, 16]
-set :puma_workers,    4
+set :puma_threads,    [1, 1]
+set :puma_workers,    8
 
 # Don't change these unless you know what you're doing
 set :pty,             true
@@ -18,18 +15,9 @@ set :puma_state,      "#{shared_path}/tmp/pids/puma.state"
 set :puma_pid,        "#{shared_path}/tmp/pids/puma.pid"
 set :puma_access_log, "#{release_path}/log/puma.access.log"
 set :puma_error_log,  "#{release_path}/log/puma.error.log"
-set :ssh_options,     { forward_agent: true, user: fetch(:user), keys: %w(~/.ssh/id_rsa.pub) }
 set :puma_preload_app, true
 set :puma_worker_timeout, nil
 set :puma_init_active_record, true  # Change to false when not using ActiveRecord
-# set :linked_files, fetch(:linked_files, []).push('config/database.yml')
-
-## Defaults:
-# set :scm,           :git
-# set :branch,        :master
-# set :format,        :pretty
-# set :log_level,     :debug
-# set :keep_releases, 5
 
 ## Linked Files & Directories (Default None):
 set :linked_files, %w{config/database.yml config/secrets.yml}
@@ -71,8 +59,7 @@ namespace :deploy do
   task :initial do
     on roles(:app) do
       before 'deploy:restart', 'puma:start'
-      execute "mkdir #{shared_path}/config -p"
-      upload! StringIO.new(File.read("config/database.yml")), "#{shared_path}/config/database.yml"
+      invoke 'upload_yml'
       invoke 'deploy'
     end
   end
@@ -89,7 +76,3 @@ namespace :deploy do
   after  :finishing,    :cleanup
   after  :finishing,    :restart
 end
-
-# ps aux | grep puma    # Get puma pid
-# kill -s SIGUSR2 pid   # Restart puma
-# kill -s SIGTERM pid   # Stop puma

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -7,6 +7,16 @@
 # server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 
+server '104.236.114.57',
+       user: 'deployer',
+       port: 2424,
+       roles: [:web, :app, :db],
+       primary: true,
+       ssh_options: {
+         forward_agent: true,
+         user: 'deployer',
+         keys: %w(~/.ssh/id_rsa.pub)
+       }
 
 
 # role-based syntax
@@ -22,7 +32,6 @@
 # role :db,  %w{deploy@example.com}
 
 
-
 # Configuration
 # =============
 # You can set any configuration variable like in config/deploy.rb
@@ -30,7 +39,6 @@
 # For available Capistrano configuration variables see the documentation page.
 # http://capistranorb.com/documentation/getting-started/configuration/
 # Feel free to add new variables to customise your setup.
-
 
 
 # Custom SSH Options


### PR DESCRIPTION
This is a small PR that cleans up `deploy.rb` a bit and changes some Puma config vars.

`server` definition was moved to `deploy/production.rb`. The whole idea of stages is that everything stage related (like server address, `ssh` port and settings, etc.) goes to `config/deploy/:stage.rb` and `config/deploy.rb` has only generic setup process that is common to any stage, be it `production` or `staging` or whatever.

Puma config was changed to single-thread mode and worker count increased to 8 workers. Reason: I don't see a lot of I/O happening in the code, so MRI Ruby won't benefit from threads due to GIL. But we have plenty of free RAM, so it makes sense to increase worker count as it will increase app throughput. 