### PR TITLE
update nginx conf with each deploy

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,67 +1,133 @@
-upstream puma {
-  server unix:///home/deployer/apps/Norma4D/shared/tmp/sockets/Norma4D-puma.sock;
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+  worker_connections 2048;
+  multi_accept on;
+  use epoll;
 }
 
-server {
-  listen 80;
-  listen [::]:80 ipv6only=on;
+http {
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 70;
+  types_hash_max_size 2048;
+  # server_tokens off;
 
-  listen 443 ssl;
-  listen [::]:443 ipv6only=on ssl;
+  server_names_hash_bucket_size 64;
+  # server_name_in_redirect off;
 
-  server_name adminliveanimations.org www.adminliveanimations.org;
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
 
-  ssl_certificate /etc/letsencrypt/live/adminliveanimations.org/fullchain.pem;
-  ssl_certificate_key /etc/letsencrypt/live/adminliveanimations.org/privkey.pem;
+  ##
+  # Logging Settings
+  ##
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
 
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-  ssl_prefer_server_ciphers on;
-  ssl_dhparam /etc/ssl/certs/dhparam.pem;
-  ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
-  ssl_session_timeout 1d;
-  ssl_session_cache shared:SSL:50m;
-  ssl_stapling on;
-  ssl_stapling_verify on;
-  add_header Strict-Transport-Security max-age=15768000;
+  reset_timedout_connection on;
 
-  proxy_set_header X-Forwarded-Ssl on;
+  open_file_cache max=5000 inactive=20s;
+  open_file_cache_valid 300s;
+  open_file_cache_min_uses 5;
+  open_file_cache_errors off;
 
-  root /home/deployer/apps/Norma4D/current/public;
-  access_log /home/deployer/apps/Norma4D/current/log/nginx.access.log combined;
-  error_log /home/deployer/apps/Norma4D/current/log/nginx.error.log error;
+  ssl_session_cache   shared:SSL:10m;
+  ssl_session_timeout 10m;
 
-  location ^~ /assets/ {
-    gzip_static on;
-    expires max;
-    add_header Cache-Control public;
+  ##
+  # Gzip Settings
+  ##
+
+  gzip on;
+  gzip_disable "msie6";
+
+  # gzip_vary on;
+  # gzip_proxied any;
+  # gzip_comp_level 6;
+  # gzip_buffers 16 8k;
+  # gzip_http_version 1.1;
+  # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+  ##
+  # Norma4D
+  ##
+
+  upstream puma {
+    server unix:///home/deployer/apps/Norma4D/shared/tmp/sockets/Norma4D-puma.sock;
   }
 
-  try_files $uri/index.html $uri @puma;
-  location @puma {
-    proxy_set_header X-Forwarded-Host 'adminliveanimations.org';
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-Ssl on;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host $http_host;
+  server {
+    server_name adminliveanimations.org www.adminliveanimations.org;
 
-    proxy_set_header X-Sendfile-Type X-Accel-Redirect;
-    proxy_set_header X-Accel-Mapping "/home/deployer/apps/Norma4D/releases/\d{14}/public/files/=/files/";
+    listen 80;
+    listen [::]:80 ipv6only=on;
 
-    proxy_redirect off;
-    proxy_read_timeout 300;
-    proxy_connect_timeout 300;
-    proxy_send_timeout 180s;
+    listen 443 ssl;
+    listen [::]:443 ipv6only=on ssl;
 
-    client_max_body_size 200M;
-    client_body_buffer_size 100M;
-    proxy_buffers 2 100M;
-    proxy_buffer_size 100M;
-    proxy_busy_buffers_size 100M;
+    ssl_certificate /etc/letsencrypt/live/adminliveanimations.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/adminliveanimations.org/privkey.pem;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_dhparam /etc/ssl/certs/dhparam.pem;
+    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
 
-    proxy_pass http://puma;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_trusted_certificate /etc/letsencrypt/live/adminliveanimations.org/chain.pem;
+    
+    add_header Strict-Transport-Security max-age=15768000;
+
+    root /home/deployer/apps/Norma4D/current/public;
+    access_log /home/deployer/apps/Norma4D/shared/log/nginx.access.log combined;
+    error_log /home/deployer/apps/Norma4D/shared/log/nginx.error.log warn;
+
+    location ^~ /assets/ {
+      gzip_static on;
+      expires max;
+      add_header Cache-Control public;
+      add_header Last-Modified "";
+      add_header ETag "";
+    }
+
+    try_files $uri/index.html $uri @puma;
+    location @puma {
+      proxy_set_header X-Forwarded-Host 'adminliveanimations.org';
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Ssl on;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+
+      proxy_set_header X-Sendfile-Type X-Accel-Redirect;
+      proxy_set_header X-Accel-Mapping "/home/deployer/apps/Norma4D/releases/\d{14}/public/files/=/files/";
+
+      proxy_redirect off;
+      proxy_read_timeout 300s;
+      proxy_connect_timeout 300s;
+      proxy_send_timeout 180s;
+
+      client_max_body_size 24M;
+      client_body_buffer_size 8M;
+
+      proxy_buffer_size 128K;
+      proxy_buffers 4 256K;
+      proxy_busy_buffers_size 256K;
+      
+      proxy_pass http://puma;
+    }
+
+    if ($request_method !~ ^(GET|HEAD|PUT|POST|DELETE|PATCH|OPTIONS)$ ){
+      return 405;
+    }
+    
+    location ~ \.(php|html)$ {
+      return 405;
+    }
+
+    error_page 500 502 503 504 /500.html;
   }
-
-  error_page 500 502 503 504 /500.html;
-  client_max_body_size 50M;
-  keepalive_timeout 30;
 }


### PR DESCRIPTION
The main goal of this PR to minimise the number of settings that we tune by logging in to the `prod` server and changing files manually, without having any history and having to do it all over again on  another host.

Much better way is to checkin your system config that the app needs into the repo and have it applied each time we do a deploy.

Another thing that this PR addresses is `nginx` fine tuning. Some of the current settings are too high without providing any performance gain.

For this to work, `deployer` user has to be able to copy files with `sudo`, so this line was added to `/etc/sudoers`:
```
deployer ALL=(ALL) NOPASSWD: /bin/cp -f config/nginx.conf /etc/nginx/nginx.conf, /bin/kill
```


I've also removed `after  :finishing,    :restart` as this functionality is already provided by `capistrano3-puma` gem.