### PR TITLE
invalidate India VPS cache when admin updates a collection or effect

### DIFF
--- a/app/controllers/concerns/india_redirectable.rb
+++ b/app/controllers/concerns/india_redirectable.rb
@@ -15,7 +15,7 @@ module IndiaRedirectable
               geo = MaxmindDB.lookup(remote_ip)
               if geo.found? && geo.country.name.in?(%w(India))
                 logger.info "This client (IP: #{remote_ip}, country: #{geo.country.name}) is redirected to India VPS"
-                redirect_to "https://india-api.liveanimations.org#{request.path}"
+                redirect_to "#{Rails.application.secrets.india_server_url}#{request.path}"
               end
             end
           end

--- a/app/jobs/invalidate_cache_job.rb
+++ b/app/jobs/invalidate_cache_job.rb
@@ -1,0 +1,10 @@
+class InvalidateCacheJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(url)
+    url = URI.parse(Rails.application.secrets.india_server_url + url)
+    req = Net::HTTP::Get.new(url.path, {'X-Bypass-Cache' => '1'}) # proxy_cache_bypass $no_cache $http_x_bypass_cache;
+    http = Net::HTTP.new(url.host, url.port)
+    http.request(req)
+  end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,10 +1,14 @@
 class Collection < ActiveRecord::Base
+  include CacheInvalidatable
+
   MEGABYTE = 1024.0 * 1024.0  
+
   belongs_to :application
   has_many :effects, dependent: :nullify
   has_many :commercials, dependent: :nullify
   has_many :collections, dependent: :nullify
   belongs_to :collection
+
   has_attached_file :small_icon, styles: { medium: '300x300>', thumb: '140x140>' },
                     url: '/files/collections/:id/small_icon/:style/small_icon.:extension',
                     path: ':rails_root/public/files/collections/:id/small_icon/:style/small_icon.:extension'
@@ -42,6 +46,9 @@ class Collection < ActiveRecord::Base
   validates :version, numericality: { greater_than_or_equal_to: 1 }
   validates :price, presence: true
   scope :avaliable, -> { where(hide: false) }
+
+  cache_invalidatable jpeg_attachments: %w(small_icon small_icon_2 large_icon large_icon_2 medium_icon medium_icon_2),
+                      other_attachments: %w(xml dat)
   
   def size
     collection_size = small_icon_size + small_icon_2_size + medium_icon_size +

--- a/app/models/concerns/cache_invalidatable.rb
+++ b/app/models/concerns/cache_invalidatable.rb
@@ -1,0 +1,35 @@
+module CacheInvalidatable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    attr_reader :jpeg_attachments, :other_attachments
+
+    def cache_invalidatable(jpeg_attachments:, other_attachments:)
+      @jpeg_attachments = jpeg_attachments
+      @other_attachments = other_attachments
+      after_update :invalidate_cache
+    end
+  end
+
+  def invalidate_cache
+    return true unless Rails.application.secrets.india_server_url
+    resource_name = self.class.name.downcase
+    self.class.jpeg_attachments.each do |attachment|
+      trigger_cache_update(attachment, resource_name, :jpg)
+    end
+    self.class.other_attachments.each do |attachment|
+      trigger_cache_update(attachment, resource_name)
+    end
+    true # because this is an ActiveRecord callback
+  end
+
+  private
+  def trigger_cache_update(attachment, resource, extension = nil )
+    if self.send("#{attachment}_updated_at_changed?")
+      method_name = "#{attachment}_application_#{resource}_path" # eg small_icon_application_effect_path
+      url = Rails.application.routes.url_helpers.send(method_name, application.id, id, extension)
+      InvalidateCacheJob.perform_later(url)
+    end
+  end
+
+end

--- a/app/models/effect.rb
+++ b/app/models/effect.rb
@@ -1,6 +1,9 @@
 class Effect < ActiveRecord::Base
+  include CacheInvalidatable
+
   belongs_to :application
   belongs_to :collection
+
   has_attached_file :small_icon, styles: { medium: '300x300>', thumb: '140x140>' },
                     url: '/files/effects/:id/small_icon/:style/small_icon.:extension',
                     path: ':rails_root/public/files/effects/:id/small_icon/:style/small_icon.:extension'
@@ -39,6 +42,11 @@ class Effect < ActiveRecord::Base
   validates_attachment_content_type :small_icon, :small_icon_2, :large_icon, :large_icon_2,
   content_type: /\Aimage\/.*\Z/
   scope :avaliable, -> { joins(:collection).where('collections.hide = false').where(hide: false) }
+
+
+  cache_invalidatable jpeg_attachments: %w(small_icon small_icon_2 large_icon large_icon_2),
+                      other_attachments: %w(assets_ios assets_android page_for_printing xml dat)
+
 
   def size
     small_icon_size + small_icon_2_size + large_icon_size + large_icon_2_size +


### PR DESCRIPTION
This PR adds a cache invalidate request feature - when the admin updates the collection/effect, a request with a special header (`X-Bypass-Cache`) is sent to the caching proxy server (the handling of this header is added in PR #5)

For this feature to work, update `config/secrets.yml` file to have these keys:
```yaml
development:
  india_server_url: "http://localhost:8088"

test:

production:
  india_server_url: "https://india-api.liveanimations.org"
```

You can drop `india_server_url` for `development` if you don't have local nginx proxy running. 